### PR TITLE
Opt out of package version update

### DIFF
--- a/apps/token-tango-widget/src/code.tsx
+++ b/apps/token-tango-widget/src/code.tsx
@@ -411,7 +411,7 @@ function saveTokensToRepository(
 ) {
   return async (
     synchDetails: RepositoryTokenLayers | null,
-    { branchName, commitMessage, version }: PushMessageType,
+    { branchName, commitMessage, version, skipVersionUpdate }: PushMessageType,
     done: () => void,
   ) => {
     log("debug", "saving tokens...");
@@ -441,6 +441,7 @@ function saveTokensToRepository(
       commitMessage,
       branchName,
       version,
+      skipVersionUpdate
     )
       .then(done)
       .catch((e) => {
@@ -547,8 +548,8 @@ function createIssueDialogCallback(state: State): () => void {
 function createPushTokensDialogCallback(
   synchConfiguration: WidgetConfiguration | null,
   setConfirmPushDialogData: (newValue: PushMessageType) => void,
-): (branch: string, message: string, version: string) => void {
-  return (branchName, commitMessage, version) =>
+): (branch: string, message: string, version: string, skipVersionUpdate: boolean) => void {
+  return (branchName, commitMessage, version, skipVersionUpdate) =>
     new Promise((resolve) => {
       figma.showUI(__html__, {
         title: "Confirm Push to Github",
@@ -563,6 +564,7 @@ function createPushTokensDialogCallback(
         ...synchConfiguration,
         branchName,
         commitMessage,
+        skipVersionUpdate,
       });
       on<UiCommitHandler>("UI_COMMIT_CHANGE", (msg) => {
         setConfirmPushDialogData({ ...msg, version });

--- a/apps/token-tango-widget/src/services/load-github.services.ts
+++ b/apps/token-tango-widget/src/services/load-github.services.ts
@@ -206,6 +206,7 @@ export const saveRepositoryTokenLayers = async (
   message: string,
   destinationBranch?: string,
   version?: string,
+  skipVersionUpdate?: boolean,
 ) => {
   const client = createGithubRepositoryClient(options.credentials);
 
@@ -223,8 +224,8 @@ export const saveRepositoryTokenLayers = async (
         path: options.tokenFilePath,
         content: JSON.stringify(tokenLayers, undefined, 2),
       },
-      // increment package.json version
-      ...(packageFileDetails && packagejson
+      // increment package.json version only if not skipping version update
+      ...(packageFileDetails && packagejson && !skipVersionUpdate
         ? [
             {
               encoding: "utf-8",

--- a/apps/token-tango-widget/src/ui/pages/loaded-page.tsx
+++ b/apps/token-tango-widget/src/ui/pages/loaded-page.tsx
@@ -42,7 +42,7 @@ type LoadedPageProps = {
   clearIcons: () => void;
   reloadTokens: () => void;
   openIssues: () => void;
-  pushTokens: (branch: string, message: string, version: string) => void;
+  pushTokens: (branch: string, message: string, version: string, skipVersionUpdate: boolean) => void;
 };
 
 const sum =

--- a/packages/radius-toolkit/src/lib/services/generate.services.ts
+++ b/packages/radius-toolkit/src/lib/services/generate.services.ts
@@ -23,7 +23,7 @@ const readTokens = async (
     return loadFile(source.fileName);
   }
   if ("content" in source) {
-    return Buffer.from(source.content as string);
+    return Buffer.from(source.content);
   }
   if ("stdin" in source) {
     return readStdin();

--- a/packages/radius-toolkit/src/lib/services/generate.services.ts
+++ b/packages/radius-toolkit/src/lib/services/generate.services.ts
@@ -23,7 +23,7 @@ const readTokens = async (
     return loadFile(source.fileName);
   }
   if ("content" in source) {
-    return Buffer.from(source.content);
+    return Buffer.from(source.content as string);
   }
   if ("stdin" in source) {
     return readStdin();

--- a/packages/repository-config/push.schema.ts
+++ b/packages/repository-config/push.schema.ts
@@ -7,4 +7,5 @@ export const pushMessageSchema = z.object({
     .regex(/^(?:[\w\-\s\.]+\/)*[\w\-\.]+$/, "Invalid branch name format")
     .min(1, "Branch is required"),
   commitMessage: z.string().min(1, "Commit message is required"),
+  skipVersionUpdate: z.boolean().optional(),
 });


### PR DESCRIPTION
Add opt out of selection to keep current package version the same.

- selecting opt out will disable manually bumping checkbox.
- if manually bump is selected prior, the skip will set back to false.
- ignore issues and publish anyway with skip version works as expected by still skipping update to the package.json